### PR TITLE
Add Equipment Capital Index to Financial Data & Market APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [Polygon.io](https://polygon.io/) – Real-time and historical financial market data APIs.
 - [Eulerpool](https://eulerpool.com/financial-data-api) – Financial data API for equities, ETFs, crypto, forex, bonds, and macroeconomic datasets.
 - [Quandl (Nasdaq Data Link)](https://data.nasdaq.com/) – Economic and financial datasets.
+- [Equipment Capital Index](https://www.equipmentcapitalindex.com/api/rate-report.json) – Free, open API for real commercial equipment financing rate and payment benchmarks, backed by a CC BY 4.0 dataset and Zenodo DOI.
 
 ## Fraud, Risk & Compliance
 


### PR DESCRIPTION
Adds a free, open API for real commercial equipment financing rate and monthly-payment benchmarks (construction, agriculture, trucking, power equipment, material handling).

- No auth required, CORS enabled
- Backed by a CC BY 4.0 open dataset (GitHub) and a permanent Zenodo DOI
- API: https://www.equipmentcapitalindex.com/api/rate-report.json
- OpenAPI spec: https://www.equipmentcapitalindex.com/openapi.json